### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/quiver-groups.cabal
+++ b/quiver-groups.cabal
@@ -24,7 +24,7 @@ library
   -- other-modules:
   build-depends:       base >=4.8 && <4.9
                      , quiver >= 1.1.3 && < 1.2
-                     , dlist >= 0.5 && < 0.8
+                     , dlist >= 0.5 && < 0.9
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `quiver-groups`, but I don't think it will be break anything.
